### PR TITLE
Feature/improve fallback

### DIFF
--- a/TouchID.h
+++ b/TouchID.h
@@ -1,6 +1,5 @@
 #import <React/RCTBridgeModule.h>
-#import <LocalAuthentication/LocalAuthentication.h>
 
 @interface TouchID : NSObject <RCTBridgeModule>
-    - (NSString *_Nonnull)getBiometryType:(LAContext *_Nonnull)context;
+
 @end

--- a/TouchID.ios.js
+++ b/TouchID.ios.js
@@ -30,8 +30,8 @@ export default {
     const DEFAULT_CONFIG = {
       fallbackLabel: null,
       unifiedErrors: false,
-      passcodeFallback: false
     };
+
     const authReason = reason ? reason : ' ';
     const authConfig = Object.assign({}, DEFAULT_CONFIG, config);
 

--- a/TouchID.ios.js
+++ b/TouchID.ios.js
@@ -14,18 +14,6 @@ const { getError, TouchIDError, TouchIDUnifiedError } = require('./errors');
  */
 
 export default {
-  isSupported(config) {
-    return new Promise((resolve, reject) => {
-      NativeTouchID.isSupported((error, biometryType) => {
-        if (error) {
-          return reject(createError(config, error.message));
-        }
-
-        resolve(biometryType);
-      });
-    });
-  },
-
   authenticate(reason, config) {
     const DEFAULT_CONFIG = {
       fallbackLabel: null,

--- a/TouchID.m
+++ b/TouchID.m
@@ -6,54 +6,22 @@
 
 RCT_EXPORT_MODULE();
 
-RCT_EXPORT_METHOD(isSupported: (RCTResponseSenderBlock)callback)
-{
-    LAContext *context = [[LAContext alloc] init];
-    NSError *error;
-
-    if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
-        callback(@[[NSNull null], [self getBiometryType:context]]);
-    }
-    else if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&error]) {
-        callback(@[[NSNull null], [self getBiometryType:context]]);
-    }
-    // Device does not support FaceID / TouchID / Pin
-    else {
-        callback(@[RCTMakeError(@"RCTTouchIDNotSupported", nil, nil)]);
-        return;
-    }
-}
-
 RCT_EXPORT_METHOD(authenticate: (NSString *)reason
                   options:(NSDictionary *)options
                   callback: (RCTResponseSenderBlock)callback)
 {
-    NSNumber *passcodeFallback = [NSNumber numberWithBool:false];
     LAContext *context = [[LAContext alloc] init];
     NSError *error;
 
-    if (RCTNilIfNull([options objectForKey:@"fallbackLabel"]) != nil) {
-        NSString *fallbackLabel = [RCTConvert NSString:options[@"fallbackLabel"]];   
-        context.localizedFallbackTitle = fallbackLabel;
-    }
-
-    if (RCTNilIfNull([options objectForKey:@"passcodeFallback"]) != nil) {
-        passcodeFallback = [RCTConvert NSNumber:options[@"passcodeFallback"]];
-    }
-
     if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&error]) {
-        // Attempt Authentification
         [context evaluatePolicy:LAPolicyDeviceOwnerAuthentication
                 localizedReason:reason
                           reply:^(BOOL success, NSError *error)
          {
              [self handleAttemptToUseDeviceIDWithSuccess:success error:error callback:callback];
          }];
-
-    }
-    else {
+    } else {
         callback(@[RCTMakeError(@"RCTTouchIDNotSupported", nil, nil)]);
-        return;
     }
 }
 

--- a/TouchID.m
+++ b/TouchID.m
@@ -26,16 +26,12 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
 }
 
 - (void)handleAttemptToUseDeviceIDWithSuccess:(BOOL)success error:(NSError *)error callback:(RCTResponseSenderBlock)callback {
-    if (success) { // Authentication Successful
+    if (success) {
         callback(@[[NSNull null], @"Authenticated with Touch ID."]);
-    } else if (error) { // Authentication Error
+    } else if (error) {
         NSString *errorReason;
         
         switch (error.code) {
-            case LAErrorAuthenticationFailed:
-                errorReason = @"LAErrorAuthenticationFailed";
-                break;
-                
             case LAErrorUserCancel:
                 errorReason = @"LAErrorUserCancel";
                 break;
@@ -61,32 +57,13 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
                 break;
                 
             default:
-                errorReason = @"RCTTouchIDUnknownError";
+                errorReason = @"LAErrorAuthenticationFailed";
                 break;
         }
         
         NSLog(@"Authentication failed: %@", errorReason);
         callback(@[RCTMakeError(errorReason, nil, nil)]);
-    } else { // Authentication Failure
-        callback(@[RCTMakeError(@"LAErrorAuthenticationFailed", nil, nil)]);
     }
-}
-
-- (NSString *)getBiometryType:(LAContext *)context
-{
-    if (@available(iOS 11, *)) {
-        if (context.biometryType == LABiometryTypeFaceID) {
-            return @"FaceID";
-        }
-        else if (context.biometryType == LABiometryTypeTouchID) {
-            return @"TouchID";
-        }
-        else if (context.biometryType == LABiometryNone) {
-            return @"None";
-        }
-    }
-
-    return @"TouchID";
 }
 
 @end

--- a/TouchID.m
+++ b/TouchID.m
@@ -1,6 +1,7 @@
 #import "TouchID.h"
 #import <React/RCTUtils.h>
 #import "React/RCTConvert.h"
+#import <LocalAuthentication/LocalAuthentication.h>
 
 @implementation TouchID
 

--- a/TouchID.m
+++ b/TouchID.m
@@ -13,8 +13,8 @@ RCT_EXPORT_METHOD(isSupported: (RCTResponseSenderBlock)callback)
 
     if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
         callback(@[[NSNull null], [self getBiometryType:context]]);
-        
-    } else if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&error]) {
+    }
+    else if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&error]) {
         callback(@[[NSNull null], [self getBiometryType:context]]);
     }
     // Device does not support FaceID / TouchID / Pin
@@ -41,18 +41,7 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
         passcodeFallback = [RCTConvert NSNumber:options[@"passcodeFallback"]];
     }
 
-    // Device has TouchID
-    if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
-        // Attempt Authentification
-        [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
-                localizedReason:reason
-                          reply:^(BOOL success, NSError *error)
-         {
-             [self handleAttemptToUseDeviceIDWithSuccess:success error:error callback:callback];
-         }];
-
-        // Device does not support TouchID but user wishes to use passcode fallback
-    } else if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&error] && [passcodeFallback boolValue]) {
+    if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&error]) {
         // Attempt Authentification
         [context evaluatePolicy:LAPolicyDeviceOwnerAuthentication
                 localizedReason:reason
@@ -60,6 +49,7 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
          {
              [self handleAttemptToUseDeviceIDWithSuccess:success error:error callback:callback];
          }];
+
     }
     else {
         callback(@[RCTMakeError(@"RCTTouchIDNotSupported", nil, nil)]);

--- a/index.d.ts
+++ b/index.d.ts
@@ -46,10 +46,6 @@ declare module 'react-native-touch-id' {
      * **iOS only** - By default specified 'Show Password' label. If set to empty string label is invisible.
      */
     fallbackLabel?: string;
-    /**
-     * **iOS only** - By default set to false. If set to true, will allow use of keypad passcode.
-     */
-    passcodeFallback?: boolean;
   }
   /**
    * `isSupported` error code

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,111 @@
+declare module 'react-native-touch-id' {
+  /**
+   * The supported biometry type
+   */
+  type BiometryType = 'FaceID' | 'TouchID';
+
+  /**
+   * Base config to pass to `TouchID.isSupported` and `TouchID.authenticate`
+   */
+  interface Config {
+    /**
+     * Return unified error messages
+     */
+    unifiedErrors?: boolean;
+  }
+
+  /**
+   * Authentication config
+   */
+  export interface AuthenticateConfig extends Config {
+    /**
+     * **Android only** - Title of confirmation dialog
+     */
+    title?: string;
+    /**
+     * **Android only** - Color of fingerprint image
+     */
+    imageColor?: string;
+    /**
+     * **Android only** - Color of fingerprint image after failed attempt
+     */
+    imageErrorColor?: string;
+    /**
+     * **Android only** - Text shown next to the fingerprint image
+     */
+    sensorDescription?: string;
+    /**
+     * **Android only** - Text shown next to the fingerprint image after failed attempt
+     */
+    sensorErrorDescription?: string;
+    /**
+     * **Android only** - Cancel button text
+     */
+    cancelText?: string;
+    /**
+     * **iOS only** - By default specified 'Show Password' label. If set to empty string label is invisible.
+     */
+    fallbackLabel?: string;
+    /**
+     * **iOS only** - By default set to false. If set to true, will allow use of keypad passcode.
+     */
+    passcodeFallback?: boolean;
+  }
+  /**
+   * `isSupported` error code
+   */
+  type IsSupportedErrorCode =
+    | 'NOT_SUPPORTED'
+    | 'NOT_AVAILABLE'
+    | 'NOT_PRESENT'
+    | 'NOT_ENROLLED';
+
+  /**
+   * `authenticate` error code
+   */
+  type AuthenticateErrorCode =
+    | IsSupportedErrorCode
+    | 'AUTHENTICATION_FAILED'
+    | 'USER_CANCELED'
+    | 'SYSTEM_CANCELED'
+    | 'TIMEOUT'
+    | 'LOCKOUT'
+    | 'LOCKOUT_PERMANENT'
+    | 'PROCESSING_ERROR'
+    | 'USER_FALLBACK'
+    | 'UNKNOWN_ERROR';
+
+  /**
+   * Error returned from `authenticate`
+   */
+  export interface AuthenticationError {
+    name: 'TouchIDError';
+    message: string;
+    code: AuthenticateErrorCode;
+    details: string;
+  }
+  /**
+   * Error returned from `isSupported`
+   */
+  export interface IsSupportedError {
+    name: 'TouchIDError';
+    message: string;
+    code: IsSupportedErrorCode;
+    details: string;
+  }
+
+  const TouchID: {
+    /**
+     *
+     * @param reason String that provides a clear reason for requesting authentication.
+     * @param config Configuration object for more detailed dialog setup
+     */
+    authenticate(reason?: string, config?: AuthenticateConfig);
+    /**
+     * 
+     * @param config - Returns a `Promise` that rejects if TouchID is not supported. On iOS resolves with a `biometryType` `String` of `FaceID` or `TouchID`
+     */
+    isSupported(config?: Config): Promise<BiometryType>;
+  };
+  export default TouchID;
+}


### PR DESCRIPTION
These changes are for iOS only. We are adapting this library to have a passcode fallback working properly.

+ Add `index.d.ts`;
+ Remove `isSupported` method, as authentication will be made anyway.