### PR TITLE
Add index.d.ts and improve passcode fallback behaviour

### DIFF
--- a/TouchID.m
+++ b/TouchID.m
@@ -26,7 +26,7 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
                   options:(NSDictionary *)options
                   callback: (RCTResponseSenderBlock)callback)
 {
-    NSNumber *passcodeFallback = [NSNumber numberWithBool:false];
+    Boolean passcodeFallback = false;
     LAContext *context = [[LAContext alloc] init];
     NSError *error;
 
@@ -36,11 +36,11 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
     }
 
     if (RCTNilIfNull([options objectForKey:@"passcodeFallback"]) != nil) {
-        passcodeFallback = [RCTConvert NSNumber:options[@"passcodeFallback"]];
+        passcodeFallback = [[RCTConvert NSNumber:options[@"passcodeFallback"]] boolValue];
     }
 
     // Only TouchID
-    if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error] && ![passcodeFallback boolValue]) {
+    if (!passcodeFallback && [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
         [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
                 localizedReason:reason
                           reply:^(BOOL success, NSError *error)
@@ -49,7 +49,7 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
          }];
 
     // TouchID or passcode
-    } else if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&error]) {
+    } else if (passcodeFallback && [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&error]) {
         [context evaluatePolicy:LAPolicyDeviceOwnerAuthentication
                 localizedReason:reason
                           reply:^(BOOL success, NSError *error)

--- a/TouchID.m
+++ b/TouchID.m
@@ -57,7 +57,7 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
              [self handleAttemptToUseDeviceIDWithSuccess:success error:error callback:callback];
          }];
     } else {
-        callback(@[RCTMakeError(@"RCTTouchIDNotSupported", nil, nil)]);
+        [self handleAttemptToUseDeviceIDWithSuccess:nil error:error callback:callback];
         return;
     }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,112 +1,111 @@
 declare module 'react-native-touch-id' {
+  /**
+   * The supported biometry type
+   */
+  type BiometryType = 'FaceID' | 'TouchID';
+
+  /**
+   * Base config to pass to `TouchID.isSupported` and `TouchID.authenticate`
+   */
+  interface IsSupportedConfig {
     /**
-     * The supported biometry type
+     * Return unified error messages
      */
-    type BiometryType = 'FaceID' | 'TouchID';
-  
-    /**
-     * Base config to pass to `TouchID.isSupported` and `TouchID.authenticate`
-     */
-    interface IsSupportedConfig {
-      /**
-       * Return unified error messages
-       */
-      unifiedErrors?: boolean;
-    }
-  
-    /**
-     * Authentication config
-     */
-    export interface AuthenticateConfig extends IsSupportedConfig {
-      /**
-       * **Android only** - Title of confirmation dialog
-       */
-      title?: string;
-      /**
-       * **Android only** - Color of fingerprint image
-       */
-      imageColor?: string;
-      /**
-       * **Android only** - Color of fingerprint image after failed attempt
-       */
-      imageErrorColor?: string;
-      /**
-       * **Android only** - Text shown next to the fingerprint image
-       */
-      sensorDescription?: string;
-      /**
-       * **Android only** - Text shown next to the fingerprint image after failed attempt
-       */
-      sensorErrorDescription?: string;
-      /**
-       * **Android only** - Cancel button text
-       */
-      cancelText?: string;
-      /**
-       * **iOS only** - By default specified 'Show Password' label. If set to empty string label is invisible.
-       */
-      fallbackLabel?: string;
-      /**
-       * **iOS only** - By default set to false. If set to true, will allow use of keypad passcode.
-       */
-      passcodeFallback?: boolean;
-    }
-    /**
-     * `isSupported` error code
-     */
-    type IsSupportedErrorCode =
-      | 'NOT_SUPPORTED'
-      | 'NOT_AVAILABLE'
-      | 'NOT_PRESENT'
-      | 'NOT_ENROLLED';
-  
-    /**
-     * `authenticate` error code
-     */
-    type AuthenticateErrorCode =
-      | IsSupportedErrorCode
-      | 'AUTHENTICATION_FAILED'
-      | 'USER_CANCELED'
-      | 'SYSTEM_CANCELED'
-      | 'TIMEOUT'
-      | 'LOCKOUT'
-      | 'LOCKOUT_PERMANENT'
-      | 'PROCESSING_ERROR'
-      | 'USER_FALLBACK'
-      | 'UNKNOWN_ERROR';
-  
-    /**
-     * Error returned from `authenticate`
-     */
-    export interface AuthenticationError {
-      name: 'TouchIDError';
-      message: string;
-      code: AuthenticateErrorCode;
-      details: string;
-    }
-    /**
-     * Error returned from `isSupported`
-     */
-    export interface IsSupportedError {
-      name: 'TouchIDError';
-      message: string;
-      code: IsSupportedErrorCode;
-      details: string;
-    }
-  
-    const TouchID: {
-      /**
-       *
-       * @param reason String that provides a clear reason for requesting authentication.
-       * @param config Configuration object for more detailed dialog setup
-       */
-      authenticate(reason?: string, config?: AuthenticateConfig);
-      /**
-       * 
-       * @param config - Returns a `Promise` that rejects if TouchID is not supported. On iOS resolves with a `biometryType` `String` of `FaceID` or `TouchID`
-       */
-      isSupported(config?: IsSupportedConfig): Promise<BiometryType>;
-    };
-    export default TouchID;
+    unifiedErrors?: boolean;
   }
-  
+
+  /**
+   * Authentication config
+   */
+  export interface AuthenticateConfig extends IsSupportedConfig {
+    /**
+     * **Android only** - Title of confirmation dialog
+     */
+    title?: string;
+    /**
+     * **Android only** - Color of fingerprint image
+     */
+    imageColor?: string;
+    /**
+     * **Android only** - Color of fingerprint image after failed attempt
+     */
+    imageErrorColor?: string;
+    /**
+     * **Android only** - Text shown next to the fingerprint image
+     */
+    sensorDescription?: string;
+    /**
+     * **Android only** - Text shown next to the fingerprint image after failed attempt
+     */
+    sensorErrorDescription?: string;
+    /**
+     * **Android only** - Cancel button text
+     */
+    cancelText?: string;
+    /**
+     * **iOS only** - By default specified 'Show Password' label. If set to empty string label is invisible.
+     */
+    fallbackLabel?: string;
+    /**
+     * **iOS only** - By default set to false. If set to true, will allow use of keypad passcode.
+     */
+    passcodeFallback?: boolean;
+  }
+  /**
+   * `isSupported` error code
+   */
+  type IsSupportedErrorCode =
+    | 'NOT_SUPPORTED'
+    | 'NOT_AVAILABLE'
+    | 'NOT_PRESENT'
+    | 'NOT_ENROLLED';
+
+  /**
+   * `authenticate` error code
+   */
+  type AuthenticateErrorCode =
+    | IsSupportedErrorCode
+    | 'AUTHENTICATION_FAILED'
+    | 'USER_CANCELED'
+    | 'SYSTEM_CANCELED'
+    | 'TIMEOUT'
+    | 'LOCKOUT'
+    | 'LOCKOUT_PERMANENT'
+    | 'PROCESSING_ERROR'
+    | 'USER_FALLBACK'
+    | 'UNKNOWN_ERROR';
+
+  /**
+   * Error returned from `authenticate`
+   */
+  export interface AuthenticationError {
+    name: 'TouchIDError';
+    message: string;
+    code: AuthenticateErrorCode;
+    details: string;
+  }
+  /**
+   * Error returned from `isSupported`
+   */
+  export interface IsSupportedError {
+    name: 'TouchIDError';
+    message: string;
+    code: IsSupportedErrorCode;
+    details: string;
+  }
+
+  const TouchID: {
+    /**
+     *
+     * @param reason String that provides a clear reason for requesting authentication.
+     * @param config Configuration object for more detailed dialog setup
+     */
+    authenticate(reason?: string, config?: AuthenticateConfig);
+    /**
+     * 
+     * @param config - Returns a `Promise` that rejects if TouchID is not supported. On iOS resolves with a `biometryType` `String` of `FaceID` or `TouchID`
+     */
+    isSupported(config?: IsSupportedConfig): Promise<BiometryType>;
+  };
+  export default TouchID;
+}


### PR DESCRIPTION
+ Add `index.d.ts` - imported from [this](https://github.com/naoufal/react-native-touch-id/pull/178) PR
+ Change native iOS `authenticate` method with the following behaviour:
  + If `passcodeFallback` field option is set to `true`: asks for [default authentication](https://developer.apple.com/documentation/localauthentication/lapolicy/lapolicydeviceownerauthentication?language=objc) method of iOS. This generally is TouchID, with option to use passcode.
  + If `passcodeFallback` field option `false` (default): asks [only for TouchID or FaceID](https://developer.apple.com/documentation/localauthentication/lapolicy/lapolicydeviceownerauthenticationwithbiometrics?language=objc), failing if not supported.
+ Change default error callback in case `canEvaluatePolicy` is false to `handleAttemptToUseDeviceIDWithSuccess` method instead of `RCTTouchIDNotSupported`. This was causing problems, for example, if either TouchID/FaceID and passcode were not set. I think the error returned should be `LAErrorPasscodeNotSet` (if passcodeFallback enabled) or `LAErrorTouchIDNotEnrolled` (if passcodeFallback disabled)

