### PR TITLE
Add fallback button with system authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ There's excellent documentation on how to do this in the [React Native Docs](htt
 
 iOS and Android differ slightly in their TouchID authentication.
 
-On Android you can customize the title and color of the pop-up by passing in the **optional config object** with a color and title key to the `authenticate` method. Even if you pass in the config object, iOS **does not** allow you change the color nor the title of the pop-up. iOS does support `passcodeFallback` as an option, which when set to `true` will allow users to use their device pin - useful for people with Face / Touch ID disabled. Passcode fallback only happens if the device does not have touch id or face id enabled.
+On Android you can customize the title and color of the pop-up by passing in the **optional config object** with a color and title key to the `authenticate` method. Even if you pass in the config object, iOS **does not** allow you change the color nor the title of the pop-up. Both Android and iOS support `passcodeFallback` as an option, which when set to `true` will allow users to use their device pin or pattern - useful for people with Face / Touch ID disabled.
 
 Error handling is also different between the platforms, with iOS currently providing much more descriptive error codes.
 
@@ -156,9 +156,9 @@ __Arguments__
   - `sensorDescription` - **Android** - text shown next to the fingerprint image
   - `sensorErrorDescription` - **Android** - text shown next to the fingerprint image after failed attempt
   - `cancelText` - **Android** - cancel button text
-  - `fallbackLabel` - **iOS** - by default specified 'Show Password' label. If set to empty string label is invisible.
+  - `fallbackLabel` - by default specified 'Fallback' label. If set to empty string label is invisible.
   - `unifiedErrors` - return unified error messages (see below) (default = false)
-  - `passcodeFallback` - **iOS** - by default set to false. If set to true, will allow use of keypad passcode.
+  - `passcodeFallback` - by default set to false. If set to true, will allow use of keypad passcode.
 
 
 __Examples__
@@ -170,9 +170,9 @@ const optionalConfigObject = {
   sensorDescription: "Touch sensor", // Android
   sensorErrorDescription: "Failed", // Android
   cancelText: "Cancel", // Android
-  fallbackLabel: "Show Passcode", // iOS (if empty, then label is hidden)
+  fallbackLabel: "Show Passcode", // if empty, then label is hidden
   unifiedErrors: false, // use unified error messages (default false)
-  passcodeFallback: false // iOS
+  passcodeFallback: false
 }
 
 TouchID.authenticate('to demo this react-native component', optionalConfigObject)

--- a/android/src/main/res/layout/fingerprint_dialog.xml
+++ b/android/src/main/res/layout/fingerprint_dialog.xml
@@ -63,17 +63,36 @@
         android:textColor="#F00"
         android:textSize="15dp" />
 
-    <Button
-        android:id="@+id/cancel_button"
-        style="?android:attr/buttonBarButtonStyle"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="bottom|right"
-        android:paddingRight="15dp"
-        android:paddingLeft="15dp"
-        android:layout_marginEnd="10dp"
-        android:background="#fff"
-        android:text="Cancel"
-        android:textColor="#696969" />
+        android:gravity="right">
+        <Button
+            android:id="@+id/fallback_button"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|right"
+            android:paddingRight="15dp"
+            android:paddingLeft="15dp"
+            android:layout_marginEnd="10dp"
+            android:visibility="gone"
+            android:background="#fff"
+            android:text="Fallback"
+            android:textColor="#696969" />
+
+        <Button
+            android:id="@+id/cancel_button"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|right"
+            android:paddingRight="15dp"
+            android:paddingLeft="15dp"
+            android:layout_marginEnd="10dp"
+            android:background="#fff"
+            android:text="Cancel"
+            android:textColor="#696969" />
+    </LinearLayout>
 
 </LinearLayout>

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,14 @@ declare module 'react-native-touch-id' {
    */
   export interface AuthenticateConfig extends IsSupportedConfig {
     /**
+     * ** By default specified 'Fallback' label. If set to empty string label is invisible.
+     */
+    fallbackLabel?: string;
+    /**
+     * ** By default set to false. If set to true, will allow use of keypad passcode.
+     */
+    passcodeFallback?: boolean;
+    /**
      * **Android only** - Title of confirmation dialog
      */
     title?: string;
@@ -42,14 +50,6 @@ declare module 'react-native-touch-id' {
      * **Android only** - Cancel button text
      */
     cancelText?: string;
-    /**
-     * **iOS only** - By default specified 'Show Password' label. If set to empty string label is invisible.
-     */
-    fallbackLabel?: string;
-    /**
-     * **iOS only** - By default set to false. If set to true, will allow use of keypad passcode.
-     */
-    passcodeFallback?: boolean;
   }
   /**
    * `isSupported` error code


### PR DESCRIPTION
### Android
+ Add fallback support:
  + User can choose pin/pattern fallback on dialog.
  + `passcodeFallback` and `fallbackLabel` are now valid options to Android.
 
+ Update README
+ Improve error text mapping:
  + When there was no authentication method, the error message was `Not supported`, when actually it was just disabled.


### Original lib
+ Could be discussed with the author/contributors, though i don't know if this would be the intended behaviour for them

### Other possibilities
+ [Same of iOS](https://github.com/alanraso/react-native-touch-id/pull/2#issuecomment-439877232).
+ Use a full native Android dialog instead of a custom fixed layout.
+ We could evaluate the effort of accepting a custom view for the dialog to possibilitate keeping the visual identity.